### PR TITLE
Add Unit + Integration Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '21.6.1'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+.tsx?$": ["ts-jest",{}],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node dist/bot.js production",
     "build": "rm -rf dist && tsc",
     "dev": "nodemon --exec ts-node-dev src/bot.ts development",
+    "test": "jest",
     "lint": "eslint . --ext .ts"
   },
   "keywords": [],
@@ -19,15 +20,19 @@
     "discord.js": "^14.17.3",
     "dotenv": "^16.3.1",
     "mongodb": "^6.12.0",
+    "mongodb-memory-server": "^10.1.3",
     "node-cron": "^3.0.3",
     "nodemon": "^3.0.3",
     "typescript": "^5.3.3"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/node-cron": "^3.0.11",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.56.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
     "ts-node-dev": "^2.0.0"
   }
 }

--- a/src/__tests__/checkinCommandIntegration.test.ts
+++ b/src/__tests__/checkinCommandIntegration.test.ts
@@ -1,0 +1,40 @@
+import {Profile} from "../types";
+import {genshinCheckin} from "../games/genshin/checkin_genshin";
+import {hkstrCheckin} from "../games/hk_starrail/checkin_hkstr";
+import {zzzCheckin} from "../games/zenless_zone_zero/checkin_zenless";
+
+describe('Check-In API Integration Tests', () => {
+
+    const testProfile: Profile = {
+        nickname: 'testUser',
+        genshin: [],
+        hk_str: [],
+        zzz: [],
+        pasted_cookie: {
+            ltoken_v2: 'TEST',
+            ltuid_v2: 'TEST',
+        },
+        raw_cookie: 'TEST',
+    };
+
+    it('should call the Genshin API and return a successful response', async () => {
+        const result: string = await genshinCheckin(testProfile);
+
+        console.log('Genshin API Response:', result);
+        expect(result).toContain('Check-in completed');
+    });
+
+    it('should call the Honkai Starrail API and return a successful response', async () => {
+        const result: string = await hkstrCheckin(testProfile);
+
+        console.log('Honkai Starrail API Response:', result);
+        expect(result).toContain('Check-in completed');
+    });
+
+    it('should call the Zenless Zone Zero API and return a successful response', async () => {
+        const result: string = await zzzCheckin(testProfile);
+
+        console.log('Zenless Zone Zero API Response:', result);
+        expect(result).toContain('Check-in completed');
+    });
+});

--- a/src/__tests__/checkinCommandUnit.test.ts
+++ b/src/__tests__/checkinCommandUnit.test.ts
@@ -1,0 +1,150 @@
+jest.mock('../games/genshin/checkin_genshin', () => ({
+    genshinCheckin: jest.fn(),
+}));
+jest.mock('../games/hk_starrail/checkin_hkstr', () => ({
+    hkstrCheckin: jest.fn(),
+}));
+jest.mock('../games/zenless_zone_zero/checkin_zenless', () => ({
+    zzzCheckin: jest.fn(),
+}));
+jest.mock('../database/userRepository', () => ({
+    findUserByDiscordId: jest.fn(),
+}));
+
+import { checkinCommand } from '../commands/checkinCommand';
+import { genshinCheckin } from '../games/genshin/checkin_genshin';
+import { hkstrCheckin } from '../games/hk_starrail/checkin_hkstr';
+import { zzzCheckin } from '../games/zenless_zone_zero/checkin_zenless';
+import { findUserByDiscordId } from '../database/userRepository';
+import { CommandInteraction } from 'discord.js';
+
+describe('checkinCommand', () => {
+    const mockInteraction = {
+        user: { id: '12345' },
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+    } as unknown as CommandInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should prompt user to register if not found in database', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue(null);
+
+        await checkinCommand(mockInteraction);
+
+        expect(mockInteraction.deferReply).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith({
+            content: 'User not found. Please register first using /register',
+        });
+    });
+
+    it('should check in Genshin Impact successfully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [
+                { nickname: 'testUser', genshin: [{}], hk_str: [], zzz: [] },
+            ],
+        });
+        (genshinCheckin as jest.Mock).mockResolvedValue('Check-in completed successfully.');
+
+        await checkinCommand(mockInteraction);
+
+        expect(genshinCheckin).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('Check-in completed successfully.'),
+            })
+        );
+    });
+
+    it('should handle Genshin Impact check-in errors gracefully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [
+                { nickname: 'testUser', genshin: [{}], hk_str: [], zzz: [] },
+            ],
+        });
+        (genshinCheckin as jest.Mock).mockRejectedValue(new Error('Failed to check in.'));
+
+        await checkinCommand(mockInteraction);
+
+        expect(genshinCheckin).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('An error occurred during the check-in process.'),
+            })
+        );
+    });
+
+    it('should check in Honkai Starrail successfully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [
+                { nickname: 'testUser', genshin: [], hk_str: [{}], zzz: [] },
+            ],
+        });
+        (hkstrCheckin as jest.Mock).mockResolvedValue('Check-in completed successfully.');
+
+        await checkinCommand(mockInteraction);
+
+        expect(hkstrCheckin).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('Check-in completed successfully.'),
+            })
+        );
+    });
+
+    it('should handle Honkai Starrail check-in errors gracefully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [
+                { nickname: 'testUser', genshin: [], hk_str: [{}], zzz: [] },
+            ],
+        });
+        (hkstrCheckin as jest.Mock).mockRejectedValue(new Error('Failed to check in.'));
+
+        await checkinCommand(mockInteraction);
+
+        expect(hkstrCheckin).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('An error occurred during the check-in process.'),
+            })
+        );
+    });
+
+    it('should check in Zenless Zone Zero successfully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [
+                { nickname: 'testUser', genshin: [], hk_str: [], zzz: [{}] },
+            ],
+        });
+        (zzzCheckin as jest.Mock).mockResolvedValue('Check-in completed successfully.');
+
+        await checkinCommand(mockInteraction);
+
+        expect(zzzCheckin).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('Check-in completed successfully.'),
+            })
+        );
+    });
+
+    it('should handle Zenless Zone Zero check-in errors gracefully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [
+                { nickname: 'testUser', genshin: [], hk_str: [], zzz: [{}] },
+            ],
+        });
+        (zzzCheckin as jest.Mock).mockRejectedValue(new Error('Failed to check in.'));
+
+        await checkinCommand(mockInteraction);
+
+        expect(zzzCheckin).toHaveBeenCalled();
+        expect(mockInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('An error occurred during the check-in process.'),
+            })
+        );
+    });
+});

--- a/src/__tests__/deleteCommandIntegration.test.ts
+++ b/src/__tests__/deleteCommandIntegration.test.ts
@@ -1,0 +1,103 @@
+import { deleteProfileCommand, deleteProfileConfirm } from '../commands/delete';
+import * as dbConnectionModule from '../database/dbConnection';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, Db } from 'mongodb';
+import { ChatInputCommandInteraction, ButtonInteraction } from 'discord.js';
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+jest.mock('../bot', () => ({
+    config: {
+        TOKEN: 'mockToken',
+        CLIENT_ID: 'mockClientId',
+        BOT_ADMIN_ID: 'mockAdminId',
+        MONGO_URI: 'mockMongoUri',
+        DATABASE_NAME: 'mockDatabase',
+    },
+}));
+
+beforeAll(async () => {
+    // Start the in-memory MongoDB server
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+
+    // Connect to the in-memory database
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db('test_database');
+
+    // Mock the connectToDatabase function
+    jest.spyOn(dbConnectionModule, 'connectToDatabase').mockResolvedValue(db);
+});
+
+afterAll(async () => {
+    // Clean up the database and stop the in-memory server
+    await db.collection('users').deleteMany({});
+    await client.close();
+    await mongod.stop();
+});
+
+describe('Integration Tests for Delete Command', () => {
+    const mockCommandInteraction = {
+        reply: jest.fn(),
+        options: {
+            getString: jest.fn(),
+        },
+        user: { id: '12345' },
+    } as unknown as ChatInputCommandInteraction;
+
+    const mockButtonInteraction = {
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        customId: 'delete_profile_confirm:testProfile',
+        user: { id: '12345' },
+    } as unknown as ButtonInteraction;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await db.collection('users').deleteMany({});
+        await db.collection('users').insertOne({
+            username: 'testUser',
+            discord_id: '12345',
+            profiles: [{ nickname: 'testProfile' }],
+        });
+    });
+
+    it('should reply with an error if the profile does not exist', async () => {
+        (mockCommandInteraction.options.getString as jest.Mock).mockReturnValue('nonexistentProfile');
+
+        await deleteProfileCommand(mockCommandInteraction);
+
+        expect(mockCommandInteraction.reply).toHaveBeenCalledWith({
+            content: 'You do not have a profile named `nonexistentProfile`.',
+            flags: expect.anything(),
+        });
+    });
+
+    it('should prompt confirmation if the profile exists', async () => {
+        (mockCommandInteraction.options.getString as jest.Mock).mockReturnValue('testProfile');
+
+        await deleteProfileCommand(mockCommandInteraction);
+
+        expect(mockCommandInteraction.reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.any(Array),
+                components: expect.any(Array),
+            })
+        );
+    });
+
+    it('should delete the profile and update the database on confirmation', async () => {
+        await deleteProfileConfirm(mockButtonInteraction);
+
+        const updatedUser = await db.collection('users').findOne({ discord_id: '12345' });
+
+        expect(updatedUser).not.toBeNull();
+        expect(updatedUser?.profiles).toEqual([]);
+        expect(mockButtonInteraction.editReply).toHaveBeenCalledWith({
+            content: 'Profile testProfile has been deleted.',
+        });
+    });
+});

--- a/src/__tests__/deleteCommandUnit.test.ts
+++ b/src/__tests__/deleteCommandUnit.test.ts
@@ -1,0 +1,69 @@
+jest.mock('../database/userRepository', () => ({
+    findUserByDiscordId: jest.fn(),
+    deleteProfile: jest.fn(),
+}));
+
+import { deleteProfileCommand, deleteProfileConfirm } from '../commands/delete';
+import { findUserByDiscordId, deleteProfile } from '../database/userRepository';
+import { ChatInputCommandInteraction, ButtonInteraction } from 'discord.js';
+
+describe('Unit Tests for Delete Command', () => {
+    const mockCommandInteraction = {
+        reply: jest.fn(),
+        options: {
+            getString: jest.fn(),
+        },
+        user: { id: '12345' },
+    } as unknown as ChatInputCommandInteraction;
+
+    const mockButtonInteraction = {
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        customId: 'delete_profile_confirm:testProfile',
+        user: { id: '12345' },
+    } as unknown as ButtonInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should reply with an error if the user has no profiles', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue(null);
+        (mockCommandInteraction.options.getString as jest.Mock).mockReturnValue('testProfile');
+
+        await deleteProfileCommand(mockCommandInteraction);
+
+        expect(findUserByDiscordId).toHaveBeenCalledWith('12345');
+        expect(mockCommandInteraction.reply).toHaveBeenCalledWith({
+            content: 'You do not have a profile named `testProfile`.',
+            flags: expect.anything(),
+        });
+    });
+
+    it('should prompt confirmation if the profile exists', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [{ nickname: 'testProfile' }],
+        });
+        (mockCommandInteraction.options.getString as jest.Mock).mockReturnValue('testProfile');
+
+        await deleteProfileCommand(mockCommandInteraction);
+
+        expect(findUserByDiscordId).toHaveBeenCalledWith('12345');
+        expect(mockCommandInteraction.reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.any(Array),
+                components: expect.any(Array),
+            })
+        );
+    });
+
+    it('should delete the profile on confirmation', async () => {
+        await deleteProfileConfirm(mockButtonInteraction);
+
+        expect(mockButtonInteraction.deferReply).toHaveBeenCalled();
+        expect(deleteProfile).toHaveBeenCalledWith('12345', 'testProfile');
+        expect(mockButtonInteraction.editReply).toHaveBeenCalledWith({
+            content: 'Profile testProfile has been deleted.',
+        });
+    });
+});

--- a/src/__tests__/registrationCommandIntegration.test.ts
+++ b/src/__tests__/registrationCommandIntegration.test.ts
@@ -1,0 +1,93 @@
+import { handleRegistrationSubmit } from '../commands/registration';
+import * as dbConnectionModule from '../database/dbConnection';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, Db } from 'mongodb';
+import { ModalSubmitInteraction } from 'discord.js';
+import {fetchGameData} from "../hoyolab/profileUtils";
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+jest.mock('../bot', () => ({
+    config: {
+        TOKEN: 'mockToken',
+        CLIENT_ID: 'mockClientId',
+        BOT_ADMIN_ID: 'mockAdminId',
+        MONGO_URI: 'mockMongoUri',
+        DATABASE_NAME: 'mockDatabase',
+    },
+}));
+
+jest.mock('../hoyolab/profileUtils', () => ({
+    parseCookies: jest.fn(),
+    fetchGameData: jest.fn(),
+}));
+
+beforeAll(async () => {
+    // Start the in-memory MongoDB server
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+
+    // Connect to the in-memory database
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db('test_database');
+
+    // Mock database connection
+    jest.spyOn(dbConnectionModule, 'connectToDatabase').mockResolvedValue(db);
+});
+
+afterAll(async () => {
+    // Close the client and stop the in-memory server
+    await client.close();
+    await mongod.stop();
+});
+
+describe('Integration Tests for Registration Command', () => {
+    const mockModalInteraction = {
+        reply: jest.fn(),
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        customId: 'registration_modal:test-id',
+        fields: {
+            getTextInputValue: jest.fn(),
+        },
+        user: { id: '12345', username: 'testUser' },
+    } as unknown as ModalSubmitInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should handle full registration flow and save user in database', async () => {
+        (mockModalInteraction.fields.getTextInputValue as jest.Mock).mockImplementation((field) => {
+            if (field === 'nickname') return 'integrationTestUser';
+            if (field === 'cookies') return 'integrationTestCookies';
+        });
+        (fetchGameData as jest.Mock).mockResolvedValue({
+            genshinUIDs: [{}],
+            hkstrUIDs: [],
+            zenlessUIDs: [],
+            responseMessage: 'Mocked response message',
+        });
+
+        await handleRegistrationSubmit(mockModalInteraction);
+
+        const savedUser = await db.collection('users').findOne({ discord_id: '12345' });
+
+        expect(savedUser).not.toBeNull();
+
+        if (!savedUser) {
+            throw new Error('User not found in database.');
+        }
+
+        expect(savedUser.profiles).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    nickname: 'integrationTestUser',
+                }),
+            ])
+        );
+    });
+});

--- a/src/__tests__/registrationCommandUnit.test.ts
+++ b/src/__tests__/registrationCommandUnit.test.ts
@@ -1,0 +1,123 @@
+jest.mock('../database/userRepository', () => ({
+    findUserByDiscordId: jest.fn(),
+    saveUser: jest.fn(),
+}));
+jest.mock('../hoyolab/profileUtils', () => ({
+    parseCookies: jest.fn(),
+    fetchGameData: jest.fn(),
+}));
+
+import { registerCommand, handleRegistrationSubmit } from '../commands/registration';
+import { findUserByDiscordId, saveUser } from '../database/userRepository';
+import { parseCookies, fetchGameData } from '../hoyolab/profileUtils';
+import { CommandInteraction, ModalSubmitInteraction } from 'discord.js';
+
+describe('Unit Tests for Registration Command', () => {
+
+    const mockCommandInteraction = {
+        reply: jest.fn(),
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        customId: 'open_registration_modal',
+        user: { id: '12345', username: 'testUser' },
+        channel: { messages: { fetch: jest.fn() } },
+    } as unknown as CommandInteraction;
+
+    const mockModalInteraction = {
+        reply: jest.fn(),
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        customId: 'registration_modal:test-id',
+        fields: {
+            getTextInputValue: jest.fn(),
+        },
+        user: { id: '12345', username: 'testUser' },
+    } as unknown as ModalSubmitInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should send registration instructions with an embed', async () => {
+        await registerCommand(mockCommandInteraction);
+
+        expect(mockCommandInteraction.reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.any(Array),
+                components: expect.any(Array),
+            })
+        );
+    });
+
+    it('should handle registration form submission for a new user', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue(null);
+        (mockModalInteraction.fields.getTextInputValue as jest.Mock).mockImplementation((field) => {
+            if (field === 'nickname') return 'testNickname';
+            if (field === 'cookies') return 'testCookies';
+        });
+        (parseCookies as jest.Mock).mockReturnValue({ test: 'parsedCookie' });
+        (fetchGameData as jest.Mock).mockResolvedValue({
+            genshinUIDs: [{}],
+            hkstrUIDs: [],
+            zenlessUIDs: [],
+            responseMessage: 'Mocked response message',
+        });
+
+        await handleRegistrationSubmit(mockModalInteraction);
+
+        expect(parseCookies).toHaveBeenCalledWith('testCookies');
+        expect(fetchGameData).toHaveBeenCalledWith('testCookies');
+        expect(saveUser).toHaveBeenCalledWith(
+            expect.objectContaining({
+                username: 'testUser',
+                discord_id: '12345',
+                profiles: expect.any(Array),
+            })
+        );
+        expect(mockModalInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('Successfully registered'),
+            })
+        );
+    });
+
+    it('should handle duplicate nicknames gracefully', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue({
+            profiles: [{ nickname: 'testNickname' }],
+        });
+        (mockModalInteraction.fields.getTextInputValue as jest.Mock).mockImplementation((field) => {
+            if (field === 'nickname') return 'testNickname';
+        });
+
+        await handleRegistrationSubmit(mockModalInteraction);
+
+        expect(mockModalInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('A profile with the same nickname already exists'),
+            })
+        );
+    });
+
+    it('should handle failed cookie validation', async () => {
+        (findUserByDiscordId as jest.Mock).mockResolvedValue(null);
+        (mockModalInteraction.fields.getTextInputValue as jest.Mock).mockImplementation((field) => {
+            if (field === 'nickname') return 'testNickname';
+            if (field === 'cookies') return 'testCookies';
+        });
+        (parseCookies as jest.Mock).mockReturnValue({ test: 'parsedCookie' });
+        (fetchGameData as jest.Mock).mockResolvedValue({
+            genshinUIDs: [],
+            hkstrUIDs: [],
+            zenlessUIDs: [],
+            responseMessage: '',
+        });
+
+        await handleRegistrationSubmit(mockModalInteraction);
+
+        expect(mockModalInteraction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('No data was found for the cookies provided'),
+            })
+        );
+    });
+});

--- a/src/__tests__/updateProfileCommandIntegration.test.ts
+++ b/src/__tests__/updateProfileCommandIntegration.test.ts
@@ -1,0 +1,115 @@
+import { updateProfileCommand } from '../commands/updateProfile';
+import * as dbConnectionModule from '../database/dbConnection';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, Db } from 'mongodb';
+import { ChatInputCommandInteraction } from 'discord.js';
+import {fetchGameData, getUserProfile} from '../hoyolab/profileUtils';
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+jest.mock('../bot', () => ({
+    config: {
+        TOKEN: 'mockToken',
+        CLIENT_ID: 'mockClientId',
+        BOT_ADMIN_ID: 'mockAdminId',
+        MONGO_URI: 'mockMongoUri',
+        DATABASE_NAME: 'mockDatabase',
+    },
+}));
+
+jest.mock('../hoyolab/profileUtils', () => ({
+    parseCookies: jest.fn(),
+    fetchGameData: jest.fn(),
+    getUserProfile: jest.fn(),
+}));
+
+beforeAll(async () => {
+    // Start the in-memory MongoDB server
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+
+    // Connect to the in-memory database
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db('test_database');
+
+    // Mock connectToDatabase to return the in-memory database
+    jest.spyOn(dbConnectionModule, 'connectToDatabase').mockResolvedValue(db);
+});
+
+afterAll(async () => {
+    // Clean up the database and stop the in-memory server
+    await db.collection('users').deleteMany({});
+    await client.close();
+    await mongod.stop();
+});
+
+describe('Integration Tests for Update Profile Command', () => {
+    const mockInteraction = {
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        options: {
+            getString: jest.fn(),
+        },
+        user: { id: '12345' },
+    } as unknown as ChatInputCommandInteraction;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await db.collection('users').deleteMany({});
+        await db.collection('users').insertOne({
+            username: 'testUser',
+            discord_id: '12345',
+            profiles: [{ nickname: 'testProfile', genshin: [] }],
+        });
+    });
+
+    it('should update the profile and save it in the database', async () => {
+        (mockInteraction.options.getString as jest.Mock).mockImplementation((option) => {
+            if (option === 'profile') return 'testProfile';
+            if (option === 'cookies') return 'testCookies';
+        });
+        (fetchGameData as jest.Mock).mockResolvedValue({
+            genshinUIDs: [{ uid: 123456 }],
+            hkstrUIDs: [],
+            zenlessUIDs: [],
+            responseMessage: 'Mocked game data fetch successful!',
+        });
+        (getUserProfile as jest.Mock).mockResolvedValue({
+            user: {
+                username: 'testUser',
+                discord_id: '12345',
+                profiles: [{ nickname: 'testProfile', genshin: [] }],
+            },
+            profileIndex: 0,
+        });
+
+        await updateProfileCommand(mockInteraction);
+
+        // Verify the database was updated
+        const updatedUser = await db.collection('users').findOne({ discord_id: '12345' });
+
+        expect(updatedUser).not.toBeNull();
+
+        if (!updatedUser) {
+            throw new Error('User not found in database.');
+        }
+
+        // Verify the profile was updated
+        expect(updatedUser.profiles).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    nickname: 'testProfile',
+                    genshin: expect.arrayContaining([{ uid: 123456 }]),
+                }),
+            ])
+        );
+
+        // Verify interaction response
+        expect(mockInteraction.editReply).toHaveBeenCalledWith({
+            content: expect.stringContaining('Profile `testProfile` updated successfully.'),
+        });
+    });
+});

--- a/src/__tests__/updateProfileCommandUnit.test.ts
+++ b/src/__tests__/updateProfileCommandUnit.test.ts
@@ -1,0 +1,104 @@
+jest.mock('../database/userRepository', () => ({
+    saveUser: jest.fn(),
+}));
+jest.mock('../hoyolab/profileUtils', () => ({
+    parseCookies: jest.fn(),
+    fetchGameData: jest.fn(),
+    getUserProfile: jest.fn(),
+}));
+
+import { updateProfileCommand } from '../commands/updateProfile';
+import { saveUser } from '../database/userRepository';
+import { parseCookies, fetchGameData, getUserProfile } from '../hoyolab/profileUtils';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+describe('Unit Tests for Update Profile Command', () => {
+    const mockInteraction = {
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        options: {
+            getString: jest.fn(),
+        },
+        user: { id: '12345' },
+    } as unknown as ChatInputCommandInteraction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should reply with an error if the profile does not exist', async () => {
+        (mockInteraction.options.getString as jest.Mock).mockImplementation((option) => {
+            if (option === 'profile') return 'testProfile';
+            if (option === 'cookies') return 'testCookies';
+        });
+        (getUserProfile as jest.Mock).mockResolvedValue(null);
+
+        await updateProfileCommand(mockInteraction);
+
+        expect(getUserProfile).toHaveBeenCalledWith('12345', 'testProfile');
+        expect(mockInteraction.editReply).toHaveBeenCalledWith({
+            content: 'No profile found with the nickname `testProfile`.',
+        });
+    });
+
+    it('should reply with an error if cookies are invalid', async () => {
+        (mockInteraction.options.getString as jest.Mock).mockImplementation((option) => {
+            if (option === 'profile') return 'testProfile';
+            if (option === 'cookies') return 'testCookies';
+        });
+        (getUserProfile as jest.Mock).mockResolvedValue({
+            user: { profiles: [] },
+            profileIndex: 0,
+        });
+        (parseCookies as jest.Mock).mockReturnValue({});
+        (fetchGameData as jest.Mock).mockResolvedValue({
+            genshinUIDs: [],
+            hkstrUIDs: [],
+            zenlessUIDs: [],
+            responseMessage: '',
+        });
+
+        await updateProfileCommand(mockInteraction);
+
+        expect(fetchGameData).toHaveBeenCalledWith('testCookies');
+        expect(mockInteraction.editReply).toHaveBeenCalledWith({
+            content: 'No data was found for the provided cookies. Please ensure they are correct.',
+        });
+    });
+
+    it('should update the profile and save the user if cookies are valid', async () => {
+        (mockInteraction.options.getString as jest.Mock).mockImplementation((option) => {
+            if (option === 'profile') return 'testProfile';
+            if (option === 'cookies') return 'testCookies';
+        });
+        (getUserProfile as jest.Mock).mockResolvedValue({
+            user: { profiles: [{ nickname: 'testProfile' }] },
+            profileIndex: 0,
+        });
+        (parseCookies as jest.Mock).mockReturnValue({ test: 'parsedCookie' });
+        (fetchGameData as jest.Mock).mockResolvedValue({
+            genshinUIDs: [{ uid: 123456 }],
+            hkstrUIDs: [],
+            zenlessUIDs: [],
+            responseMessage: 'Mocked game data fetch successful!',
+        });
+
+        await updateProfileCommand(mockInteraction);
+
+        expect(parseCookies).toHaveBeenCalledWith('testCookies');
+        expect(fetchGameData).toHaveBeenCalledWith('testCookies');
+        expect(saveUser).toHaveBeenCalledWith(
+            expect.objectContaining({
+                profiles: expect.arrayContaining([
+                    expect.objectContaining({
+                        nickname: 'testProfile',
+                        genshin: expect.arrayContaining([{ uid: 123456 }]),
+                    }),
+                ]),
+            })
+        );
+        expect(mockInteraction.editReply).toHaveBeenCalledWith({
+            content: expect.stringContaining('Profile `testProfile` updated successfully.'),
+        });
+    });
+});

--- a/src/games/genshin/checkin_genshin.ts
+++ b/src/games/genshin/checkin_genshin.ts
@@ -1,14 +1,13 @@
 import {Profile} from "../../types";
 
 export async function genshinCheckin(profile: Profile): Promise<string> {
-    
+
     const url = 'https://sg-hk4e-api.hoyolab.com/event/sol/sign?lang=en-us&act_id=e202102251931481';
     const nickname = profile.nickname;
     const cookies = 'ltoken_v2='+profile.pasted_cookie.ltoken_v2+';'+'ltuid_v2='+profile.pasted_cookie.ltuid_v2+';';
 
     if (!url) {
         return `Check-in skipped for ${nickname}: Genshin Impact check-in is disabled.`;
-        
     }
 
     const header = {
@@ -22,12 +21,12 @@ export async function genshinCheckin(profile: Profile): Promise<string> {
         'Referer': 'https://act.hoyolab.com/',
         'Origin': 'https://act.hoyolab.com',
     };
-    
+
     const options: RequestInit = {
         method: 'POST',
         headers: header,
     };
-  
+
     // Check-in the profile
     try {
         const hoyolabResponse: Response = await fetch(url, options);


### PR DESCRIPTION
## **Summary**
This pull request adds unit and integration tests for the following commands:
- `checkinCommand`
- `registrationCommand`
- `deleteProfileCommand`
- `updateProfileCommand`

Additionally, it introduces a GitHub Actions workflow to automatically run these tests for pull requests targeting the `main` branch.

---

## **Changes Implemented**

### **1. Unit Tests**
- **Added Unit Tests for:**
  - `checkinCommand` 
  - `registrationCommand`
  - `deleteProfileCommand`
  - `updateProfileCommand`
- **Test Coverage Includes:**
  - Mocking database functions (`findUserByDiscordId`, `saveUser`, `deleteProfile`).
  - Mocking external dependencies (`fetchGameData`, `getUserProfile`, `parseCookies`).
  - Testing edge cases (e.g., missing profiles, invalid cookies, duplicate data).

### **2. Integration Tests**
- **Added Integration Tests for:**
  - `checkinCommand`
  - `registrationCommand`
  - `deleteProfileCommand`
  - `updateProfileCommand`
- **Test Coverage Includes:**
  - Using `mongodb-memory-server` for an in-memory MongoDB instance.
  - Verifying database changes for user creation, profile updates, and profile deletion.
  - Mocking external dependencies (`fetchGameData`, `getUserProfile`) while ensuring database integrity.

### **3. GitHub Actions Workflow**
- Added a `test.yml` workflow to run tests on pull requests targeting the `main` branch.

---
