### PR TITLE
First phase of rate limiting

### DIFF
--- a/src/hoyolab/checkinAllUsers.ts
+++ b/src/hoyolab/checkinAllUsers.ts
@@ -11,6 +11,7 @@ export async function checkinAllUsers() {
     // Gather all user's information from database
     const users: User[] = await getAllUsers();
 
+
     for(const user of users){
 
         logger.info(`--Checking in user: ${user.username}--`);
@@ -35,6 +36,9 @@ export async function checkinAllUsers() {
                 const zzzResult: string = await zzzCheckin(profile);
                 logger.info(zzzResult);
             }
+
+            // Delay between check-ins
+            await new Promise(resolve => setTimeout(resolve, 2000));
         }
     }
 }


### PR DESCRIPTION
When checking in all users, a "Too Many Requests" is sent and about half the users miss a checkin. Mainly for Genshin. A 2 second delay between checkins for users in the `checkAllUsers()` function has been added.

Phase 2 will include a rate limit for users in general. I do not think this is necessary as of now but it may be in the future. 